### PR TITLE
Created Uninstall procedure for RabbitMQ

### DIFF
--- a/docs/upgrade/Uninstall-RabbitMQ.md
+++ b/docs/upgrade/Uninstall-RabbitMQ.md
@@ -1,0 +1,54 @@
+**Purpose:**
+
+This guide is to walk through the process of upgrading RabbitMQ, the current process for this involves uninstalling completely, and then re-installing RabbitMQ using the approved Thycotic RabbitMQ Helper.
+
+**Pre-Requisites:**
+
+RabbitMQ is currently installed in the environment and may be clustered or federated. Take note of clustering / federation configuration policies before the upgrade. To find these:
+
+1.	Navigate to the Local RabbitMQ node.
+2.	Open a web-browser, and browse to http://localhost:15672
+3.	Log-In to the RabbitMQ Management portal with administrative username and password. (Default is guest/guest)
+4.	Click the Policies Tab.
+5.	Take note of any configuration items that exist here.
+
+**Uninstall:**
+
+1.	Uninstall any previous version of the RabbitMQ Helper:
+
+    a.	Navigate to the Control Panel > Programs and Features > RabbitMQ Helper > Remove / Uninstall
+2.	Install the newest version of the Helper, Right-Click then Run as Administrator.
+3.	Once the new Helper has Installed, ensure you are logged into the system as a local user who is an explicit member of the Local Administrators Group. 
+4.	Navigate to the RabbitMQ Helper folder (Default is C:\Program Files\Thycotic Software Ltd\RabbitMq Helper)
+5.	Once there, right click the RabbitMQ Helper executable: Thycotic.RabbitMq.Helper.exe, and choose, run as Administrator. This will create the RabbitMQ Administrative Powershell Session that has the Powershell Module loaded into it already.
+6.	If your RabbitMQ instance is a member of a cluster, run the following command in the RabbitMQ Helper: **Reset-RabbitMQNodeCommand -force**
+
+7.	To uninstall the current version of RabbitMQ, run the following command in the RabbitMQ Helper: **Uninstall-Connector**
+
+    a.	Uninstall-Connector will run, removing the various configuration items for the current RabbitMQ installation. Note if you receive any errors in this step, run Uninstall-Connector again until no errors are returned.
+
+8.	Verify all pieces of Erlang and RabbitMQ are removed:
+
+    a.	Browse to “C:\Program Files”, ensure that the folder erl9.3 (Note: the numbers next to the folder name may change, based on the current version of Erlang Installed) has been removed, if it has not, attempt to delete this folder.
+
+    -	If you are unable to delete any folder due to file locks, a reboot will be required, after the reboot has finished, the file locks should be removed, and you should be able to delete the folder.
+
+    b.	Verify all .erlang.cookie files have been deleted, the 3 possible locations are:
+
+    - User cookie if both HOMEDRIVE and HOMEPATH environment variables are set: %HOMEDRIVE%%HOMEPATH%\.erlang.cookie 	(Ususally C:\Windows\.erlang.cookie)
+
+    - User cookie if both HOMEDRIVE and HOMEPATH environment variables are not set:  %USERPROFILE%\.erlang.cookie  (Usually C:\Users\CURRENTUSER\.erlang.cookie)
+
+    - Service: For the RabbitMQ Windows service - %USERPROFILE%\.erlang.cookie (usually C:\WINDOWS\system32\config\systemprofile)  
+
+    c.	In “C:\Program Files”, ensure that the folder “RabbitMQ Server” has been removed, if it has not, attempt to delete it.
+
+    d.	Next, browse to “C:\Users\USER_THAT_INSTALLED_RABBITMQ\AppData\Roaming\RabbitMQ”
+
+    -	Replace “USER_THAT_INSTALLED_RABBITMQ”, with the username of the user who originally installed RabbitMQ.
+
+    e.	Ensure that the RabbitMQ folder located in the Roaming Profile has been deleted, if it has not, delete it. 
+
+    f. If the RabbitMQ Service in Services.msc still exists, it needs to be removed. From and administrative command prompt run the following command: **sc delete rabbitmq**
+
+9.	Procedure Complete: RabbitMQ is now fully uninstalled, and can be re-installed to upgrade to the latest version.

--- a/docs/upgrade/Uninstall-RabbitMQ.md
+++ b/docs/upgrade/Uninstall-RabbitMQ.md
@@ -1,54 +1,68 @@
-**Purpose:**
+# Uninstall RabbitMQ
 
-This guide is to walk through the process of upgrading RabbitMQ, the current process for this involves uninstalling completely, and then re-installing RabbitMQ using the approved Thycotic RabbitMQ Helper.
+## Purpose
 
-**Pre-Requisites:**
+* This guide is to walk through the process of upgrading RabbitMQ, the current process for this involves uninstalling completely, and then re-installing RabbitMQ using the approved Thycotic RabbitMQ Helper.
 
-RabbitMQ is currently installed in the environment and may be clustered or federated. Take note of clustering / federation configuration policies before the upgrade. To find these:
+## Pre-Requisites
 
-1.	Navigate to the Local RabbitMQ node.
-2.	Open a web-browser, and browse to http://localhost:15672
-3.	Log-In to the RabbitMQ Management portal with administrative username and password. (Default is guest/guest)
-4.	Click the Policies Tab.
-5.	Take note of any configuration items that exist here.
+* RabbitMQ is currently installed in the environment and may be clustered or federated. Take note of clustering / federation configuration policies before the upgrade. To find these:
 
-**Uninstall:**
+*	Navigate to the Local RabbitMQ node.
+*	Open a web-browser, and browse to http://localhost:15672
+*	Log-In to the RabbitMQ Management portal with administrative username and password. (Default is guest/guest)
+*	Click the Policies Tab.
+*	Take note of any configuration items that exist here.
 
-1.	Uninstall any previous version of the RabbitMQ Helper:
+## Uninstall
 
-    a.	Navigate to the Control Panel > Programs and Features > RabbitMQ Helper > Remove / Uninstall
-2.	Install the newest version of the Helper, Right-Click then Run as Administrator.
-3.	Once the new Helper has Installed, ensure you are logged into the system as a local user who is an explicit member of the Local Administrators Group. 
-4.	Navigate to the RabbitMQ Helper folder (Default is C:\Program Files\Thycotic Software Ltd\RabbitMq Helper)
-5.	Once there, right click the RabbitMQ Helper executable: Thycotic.RabbitMq.Helper.exe, and choose, run as Administrator. This will create the RabbitMQ Administrative Powershell Session that has the Powershell Module loaded into it already.
-6.	If your RabbitMQ instance is a member of a cluster, run the following command in the RabbitMQ Helper: **Reset-RabbitMQNodeCommand -force**
+*	Navigate to the Control Panel > Programs and Features > RabbitMQ Helper > Remove / Uninstall
+*	Install the newest version of the [RabbitMQ Helper](https://updates.thycotic.net/links.ashx?RabbitMqInstaller).
+*	Once the new Helper has Installed, ensure you are logged into the system as a local user who is an explicit member of the Local Administrators Group. 
+*	Navigate to the RabbitMQ Helper folder (Default is C:\Program Files\Thycotic Software Ltd\RabbitMq Helper)
+*	Once there, right click the RabbitMQ Helper executable: Thycotic.RabbitMq.Helper.exe, and choose, run as Administrator. This will create the RabbitMQ Administrative Powershell Session that has the Powershell Module loaded into it already.
+*	If your RabbitMQ instance is a member of a cluster, run the following command in the RabbitMQ Helper:
+```powershell
 
-7.	To uninstall the current version of RabbitMQ, run the following command in the RabbitMQ Helper: **Uninstall-Connector**
+Reset-RabbitMQNodeCommand -force
 
-    a.	Uninstall-Connector will run, removing the various configuration items for the current RabbitMQ installation. Note if you receive any errors in this step, run Uninstall-Connector again until no errors are returned.
+```
 
-8.	Verify all pieces of Erlang and RabbitMQ are removed:
+*	To uninstall the current version of RabbitMQ, run the following command in the RabbitMQ Helper:
 
-    a.	Browse to “C:\Program Files”, ensure that the folder erl9.3 (Note: the numbers next to the folder name may change, based on the current version of Erlang Installed) has been removed, if it has not, attempt to delete this folder.
+```powershell
 
-    -	If you are unable to delete any folder due to file locks, a reboot will be required, after the reboot has finished, the file locks should be removed, and you should be able to delete the folder.
+# Uninstall-Connector will remove the RabbitMQ Site connector, Erlang, and RabbitMQ.
+Uninstall-Connector
 
-    b.	Verify all .erlang.cookie files have been deleted, the 3 possible locations are:
+```
+    >   If you receive any errors in this step, run Uninstall-Connector again until no errors are returned.
 
-    - User cookie if both HOMEDRIVE and HOMEPATH environment variables are set: %HOMEDRIVE%%HOMEPATH%\.erlang.cookie 	(Ususally C:\Windows\.erlang.cookie)
+##	Verify all pieces of Erlang and RabbitMQ are removed:
 
-    - User cookie if both HOMEDRIVE and HOMEPATH environment variables are not set:  %USERPROFILE%\.erlang.cookie  (Usually C:\Users\CURRENTUSER\.erlang.cookie)
+*	Browse to “C:\Program Files”, ensure that the folder erl9.3 (Note: the numbers next to the folder name may change, based on the current version of Erlang Installed) has been removed, if it has not, attempt to delete this folder.
 
-    - Service: For the RabbitMQ Windows service - %USERPROFILE%\.erlang.cookie (usually C:\WINDOWS\system32\config\systemprofile)  
+*	If you are unable to delete any folder due to file locks, a reboot will be required, after the reboot has finished, the file locks should be removed, and you should be able to delete the folder.
 
-    c.	In “C:\Program Files”, ensure that the folder “RabbitMQ Server” has been removed, if it has not, attempt to delete it.
+*	Verify all .erlang.cookie files have been deleted, the 3 possible locations are:
 
-    d.	Next, browse to “C:\Users\USER_THAT_INSTALLED_RABBITMQ\AppData\Roaming\RabbitMQ”
+    * User cookie if both HOMEDRIVE and HOMEPATH environment variables are set: %HOMEDRIVE%%HOMEPATH%\.erlang.cookie 	(Ususally C:\Windows\.erlang.cookie)
 
-    -	Replace “USER_THAT_INSTALLED_RABBITMQ”, with the username of the user who originally installed RabbitMQ.
+    * User cookie if both HOMEDRIVE and HOMEPATH environment variables are not set:  %USERPROFILE%\.erlang.cookie  (Usually C:\Users\CURRENTUSER\.erlang.cookie)
 
-    e.	Ensure that the RabbitMQ folder located in the Roaming Profile has been deleted, if it has not, delete it. 
+    * Service: For the RabbitMQ Windows service - %USERPROFILE%\.erlang.cookie (usually C:\WINDOWS\system32\config\systemprofile)  
 
-    f. If the RabbitMQ Service in Services.msc still exists, it needs to be removed. From and administrative command prompt run the following command: **sc delete rabbitmq**
+*	In “C:\Program Files”, ensure that the folder “RabbitMQ Server” has been removed, if it has not, attempt to delete it.
 
-9.	Procedure Complete: RabbitMQ is now fully uninstalled, and can be re-installed to upgrade to the latest version.
+*	Next, browse to “C:\Users\USER_THAT_INSTALLED_RABBITMQ\AppData\Roaming\RabbitMQ”
+
+    >	Replace “USER_THAT_INSTALLED_RABBITMQ”, with the username of the user who originally installed RabbitMQ.
+
+*	Ensure that the RabbitMQ folder located in the Roaming Profile has been deleted, if it has not, delete it. 
+
+* If the RabbitMQ Service in Services.msc still exists, it needs to be removed. From and administrative command prompt run the following command:
+   ```cmd 
+   sc delete rabbitmq
+   ```
+##	Procedure Complete
+* RabbitMQ is now fully uninstalled, and can be re-installed to upgrade to the latest version.

--- a/docs/upgrade/blue-green-upgrade.md
+++ b/docs/upgrade/blue-green-upgrade.md
@@ -1,31 +1,44 @@
-**Blue-Green Upgrade Procedure**
+# Blue-Green Upgrade Procedure
 
-**Purpose**
+## Purpose
+
 This procedure is used to upgrade your RabbitMQ Cluster one node at a time to allow for continuous up-time of RabbitMQ services during an upgrade. The procedure is completed by breaking each node out of the cluster, upgrading it, then rejoining it to the cluster.
 
-**Procedure**
+## Procedure
 
-1. Navigate in the Secret Server Web Interface to Admin > Distributed Engine > Manage Site Connectors
+### Point Secret Server Site Connector at "Primary" Node
+* Navigate in the Secret Server Web Interface to Admin > Distributed Engine > Manage Site Connectors
 
-    - Choose the site connector you’d like to upgrade, and change the URL to point to the “Primary” RabbitMQ Node
-    	- Depending on your LB configuration (and how traffic is routed), you may be able to leave this setting to the LB url and rely on the loadbalancer not to route traffic to the node you are upgrading.
-	- Press the "Validate Connectivity" button and ensure Secret Server can still connect to RabbitMQ
+    * Choose the site connector you’d like to upgrade, and change the URL to point to the “Primary” RabbitMQ Node
+    	* Depending on your LB configuration (and how traffic is routed), you may be able to leave this setting to the LB url and rely on the loadbalancer not to route traffic to the node you are upgrading.
+	* Press the "Validate Connectivity" button and ensure Secret Server can still connect to RabbitMQ
 
-2. Next, RDP into the Secondary RabbitMQ Node, install the lastest version of the RabbitMQ helper from: https://updates.thycotic.net/links.ashx?RabbitMqInstaller
+### Remove "Secondary" Node from the Cluster
+* Next, RDP into the "Secondary" RabbitMQ Node, install the lastest version of the [RabbitMQ Helper](https://updates.thycotic.net/links.ashx?RabbitMqInstaller)
 
-	-  Log into the RabbitMQ Management GUI at http://localhost:15672, and take note of any cluster policies listed under Admin > Policies
-	-  Once the helper has installed, navigate to the install directory (Default is C:\ProgramFiles\Thycotic Software ltd\RabbitMQ Helper) and run the Helper application. It will open an administrative Powershell Session.
-		- Run the command “Reset-RabbitMQNodeCommand -Force”
-				 This command will remove the current node from the cluster. 
+	*  Log into the RabbitMQ Management GUI at http://localhost:15672, and take note of any cluster policies listed under Admin > Policies
+	*  Once the helper has installed, navigate to the install directory (Default is C:\ProgramFiles\Thycotic Software ltd\RabbitMQ Helper) and run the Helper application. It will open an administrative Powershell Session.
+		* On the "Secondary" Node:  ```Reset-RabbitMQNodeCommand -Force``` -  This command will remove the current node from the cluster. 
+```powershell
 
-3. Follow the Uninstall Procedure: https://thycotic.github.io/rabbitmq-helper/usecases/upgrade/uninstall 
+Reset-RabbitMQNodeCommand -Force
 
-4. Then Follow the installation instructions from the RabbitMQ Helper Page:  https://thycotic.github.io/rabbitmq-helper/usecases/installation/
+```
 
-5. RabbitMQ is installed on the new node, navigate to Secret Server, and point the site connector at your newly installed node. You should be able to validate connectivity if the user was installed correctly.
+### Uninstall 
+* Follow the [uninstall instructions](./uninstall-rabbitmq.md) from the RabbitMQ Helper page.  
 
-6. Once RabbitMQ is pointed to the upgraded node, repeat the uninstallation / reinstallation process for the “primary” RabbitMQ node.
+### Re-Install
+* Follow the [install instructions](../usecases/installation) from the RabbitMQ Helper page.
 
-7. Follow the Clustering Instructions here: https://thycotic.github.io/rabbitmq-helper/usecases/clustering/
 
-8. Install the policies as previously annotated. After both nodes are upgraded and clustered, shift the Site connector URL back to the Load Balancer URL.
+### Point Secret Server Site Connector at Newly installed Node
+* RabbitMQ is installed on the new node, navigate to Secret Server, and point the site connector at your newly installed node. You should be able to validate connectivity if the user was installed correctly.
+
+### Repeat Steps for "Primary"
+* Once RabbitMQ is pointed to the upgraded node, repeat the uninstallation / reinstallation process for the “primary” RabbitMQ node.
+
+### Cluster Newly installed Nodes
+* Follow the [Clustering Instructions](../usecases/clustering).
+
+* Install the policies as previously annotated. After both nodes are upgraded and clustered, shift the Site connector URL back to the Load Balancer URL.

--- a/docs/upgrade/blue-green-upgrade.md
+++ b/docs/upgrade/blue-green-upgrade.md
@@ -1,3 +1,31 @@
-# Blue-Green Upgrade
+**Blue-Green Upgrade Procedure**
 
-*Coming soon...*
+**Purpose**
+This procedure is used to upgrade your RabbitMQ Cluster one node at a time to allow for continuous up-time of RabbitMQ services during an upgrade. The procedure is completed by breaking each node out of the cluster, upgrading it, then rejoining it to the cluster.
+
+**Procedure**
+
+1. Navigate in the Secret Server Web Interface to Admin > Distributed Engine > Manage Site Connectors
+
+    - Choose the site connector you’d like to upgrade, and change the URL to point to the “Primary” RabbitMQ Node
+    	- Depending on your LB configuration (and how traffic is routed), you may be able to leave this setting to the LB url and rely on the loadbalancer not to route traffic to the node you are upgrading.
+	- Press the "Validate Connectivity" button and ensure Secret Server can still connect to RabbitMQ
+
+2. Next, RDP into the Secondary RabbitMQ Node, install the lastest version of the RabbitMQ helper from: https://updates.thycotic.net/links.ashx?RabbitMqInstaller
+
+	-  Log into the RabbitMQ Management GUI at http://localhost:15672, and take note of any cluster policies listed under Admin > Policies
+	-  Once the helper has installed, navigate to the install directory (Default is C:\ProgramFiles\Thycotic Software ltd\RabbitMQ Helper) and run the Helper application. It will open an administrative Powershell Session.
+		- Run the command “Reset-RabbitMQNodeCommand -Force”
+				 This command will remove the current node from the cluster. 
+
+3. Follow the Uninstall Procedure: https://thycotic.github.io/rabbitmq-helper/usecases/upgrade/uninstall 
+
+4. Then Follow the installation instructions from the RabbitMQ Helper Page:  https://thycotic.github.io/rabbitmq-helper/usecases/installation/
+
+5. RabbitMQ is installed on the new node, navigate to Secret Server, and point the site connector at your newly installed node. You should be able to validate connectivity if the user was installed correctly.
+
+6. Once RabbitMQ is pointed to the upgraded node, repeat the uninstallation / reinstallation process for the “primary” RabbitMQ node.
+
+7. Follow the Clustering Instructions here: https://thycotic.github.io/rabbitmq-helper/usecases/clustering/
+
+8. Install the policies as previously annotated. After both nodes are upgraded and clustered, shift the Site connector URL back to the Load Balancer URL.


### PR DESCRIPTION
This is the basis for a blue green upgrade. The uninstall instructions can be followed to completely remove a rabbit MQ node.