### PR TITLE
#177297

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,9 +4,7 @@
 
 # RabbitMQ Helper
 
-The RabbitMQ Helper is a tool whose purpose is to assist with installing [RabbitMQ](https://www.rabbitmq.com)
-
-RabbitMQ is not a Thycotic product and we do not receive revenue for it. We built the RabbitMQ Helper to help our customers more easily install RabbitMQ (RabbitMQ is an important component of Secret Server’s on-premises environment).
+[RabbitMQ](https://www.rabbitmq.com) is an important component of Secret Server’s on-premises environment, but it is not a Thycotic product and we do not receive revenue for it. We built the RabbitMQ Helper to help our customers more easily install RabbitMQ on Windows. Only versions of RabbitMQ/Erlang installed through the Thycotic Rabbit MQ Helper are directly supported. You can download Rabbit MQ Helper [here](https://updates.thycotic.net/links.ashx?RabbitMqInstaller). 
 
 ## What can the Helper do for Me?
 

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -5,7 +5,7 @@
 # Installation
 
 ## Overview
-The RabbitMQ Helper is a tool that streamlines the RabbitMQ installation on Windows. See [Downloading and Installing RabbitMQ](https://www.rabbitmq.com/download.html) and [Installing on Windows](https://www.rabbitmq.com/install-windows.html) for vanilla instructions. 
+The RabbitMQ Helper is a tool that streamlines the RabbitMQ installation on Windows. Only versions of RabbitMQ/Erlang installed through the Thycotic Rabbit MQ Helper are directly supported. You can download Rabbit MQ Helper [here](https://updates.thycotic.net/links.ashx?RabbitMqInstaller). 
 
 While the Helper has individual cmdlets that perform the different installation/un-installation steps, it also contains two workflow cmdlets called ```Install-Connector``` and ```Uninstall-Connector```.
 


### PR DESCRIPTION
1. https://docs.thycotic.com/rabbitmq-helper/2.0.0
Added: Only versions of RabbitMQ/Erlang installed through the Thycotic Rabbit MQ Helper are directly supported. You can download Rabbit MQ Helper here.

2. https://docs.thycotic.com/rabbitmq-helper/2.0.0/installation
Replaced: See Downloading and Installing RabbitMQ and Installing on Windows for vanilla instructions.
With: Only versions of RabbitMQ/Erlang installed through the Thycotic Rabbit MQ Helper are directly supported. You can download Rabbit MQ Helper here.