### PR TITLE
#221065

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,10 @@
-[title]: # (RabbitMq Helper)
+[title]: # (RabbitMq and RabbitMQ Helper)
 [tags]: # (rabbitmq,helper,powershell,cmdlet)
 [priority]: # (1)
 
-# RabbitMQ Helper
+# RabbitMQ and RabbitMQ Helper
 
-[RabbitMQ](https://www.rabbitmq.com) is an important component of Secret Server’s on-premises environment, but it is not a Thycotic product and we do not receive revenue for it. We built the RabbitMQ Helper to help our customers more easily install RabbitMQ on Windows. Only versions of RabbitMQ/Erlang installed through the Thycotic Rabbit MQ Helper are directly supported. You can download Rabbit MQ Helper [here](https://updates.thycotic.net/links.ashx?RabbitMqInstaller). 
+RabbitMQ is an important component of Secret Server’s on-premises environment, providing a robust framework for queuing messages between Secret Server and its Distributed Engines. RabbitMQ is an enterprise-ready software package that provides reliability and clustering functionality superior to other applications. For detailed information about RabbitMQ go to https://www.rabbitmq.com/. RabbitMQ is not a Thycotic product and we receive do revenue from it. We provide direct support for versions of RabbitMQ/Erlang only when they are installed through the Thycotic Rabbit MQ Helper in Windows.
 
 ## What can the Helper do for Me?
 
@@ -18,28 +18,8 @@
 - Create basic users
 - View/manage the RabbitMQ log 
 
-## Prerequisites
-
-- Download and install the latest RabbitMQ Helper
-    - Stable:
-        - [Thycotic Updates - Alias to the Thycotic CDN](https://updates.thycotic.net/links.ashx?RabbitMqInstaller)
-        - [Directly from Thycotic CDN](https://thycocdn.azureedge.net/engineinstallerfiles-master/rabbitMqSiteConnector/grmqh.msi)
-    - Pre-release
-        - [Pre-release drop](https://thycodevstorage.blob.core.windows.net/engineinstallerfiles-qa/rabbitMqSiteConnector/grmqh.msi)
-
-- Start the Helper. This will prepare and run a PowerShell instance that is pre-configured to use the Helper PowerShell module.
-    - Use the Start Menu shortcut for "Thycotic RabbitMQ Helper PowerShell Host"
-    - Or navigate to the installation folder in "%PROGRAMFILES%\Thycotic Software Ltd\RabbitMq Helper"
-- Run PowerShell commandlets directly or use any of the example scripts provided.
-
- 
-   ##### For Offline Installs:
-   - [Preparing for Installation on a Computer NOT Connected to the Internet](installation/prepare-offline.md)
-
-
 ## Installation
    - [Installation Overview](installation/index.md)
-
 
 ## Advanced
 

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -2,28 +2,64 @@
 [tags]: # (rabbitmq,installation)
 [priority]: # (100)
 
-# Installation
+# Installing RabbitMQ with RabbitMQ Helper
 
-## Overview
-The RabbitMQ Helper is a tool that streamlines the RabbitMQ installation on Windows. Only versions of RabbitMQ/Erlang installed through the Thycotic Rabbit MQ Helper are directly supported. You can download Rabbit MQ Helper [here](https://updates.thycotic.net/links.ashx?RabbitMqInstaller). 
+## RabbitMQ and RabbitMQ Helper
+RabbitMQ is an important component of Secret Server’s on-premises environment, providing a robust framework for queuing messages between Secret Server and its Distributed Engines. RabbitMQ is an enterprise-ready software package that provides reliability and clustering functionality superior to other applications. RabbitMQ is not a Thycotic product and we receive no revenue from it. For download links and detailed information about RabbitMQ go to https://www.rabbitmq.com/. 
 
-While the Helper has individual cmdlets that perform the different installation/un-installation steps, it also contains two workflow cmdlets called ```Install-Connector``` and ```Uninstall-Connector```.
+We built the Thycotic RabbitMQ Helper application to streamline our customers’ RabbitMQ installations. Thycotic only supports RabbitMQ/Erlang installations performed using RabbitMQ Helper on the Windows OS. 
 
-## Installation Examples with Arguments
+The Helper provides multiple commandlets that perform the installation/un-installation steps, along with two workflow commandlets named ```Install-Connector``` and ```Uninstall-Connector```.
 
-> The below links show the four main scenarios when installing RabbitMQ using the Rabbit Helper and how to deploy Rabbit in each scenario. Pick the link which applies to you for example commands
-- [Simple installation of RabbitMQ without TLS from a computer connected to the Internet](installnontls.md)
-- [Simple installation of RabbitMQ without TLS from a computer NOT connected to the Internet](installnontls-offline.md)
-- [Advanced installation of RabbitMQ with TLS from a computer connected to the Internet](installtls.md)
-- [Advanced installation of RabbitMQ with TLS from a computer NOT connected to the Internet](installtls-offline.md)
+## Install RabbitMQ and set up a Site Connector
+1. Download RabbitMQ from the RabbitMQ [website](https://www.rabbitmq.com/). 
+1. Check the RabbitMQ installation [prerequisites and set up a Site Connector](https://docs.thycotic.com/ss/10.9.0/secret-server-setup/installation/installing-rabbitmq/index.md) in Secret Server
+
+
+## Install RabbitMQ Helper
+> **Note**: Before installing RabbitMQ Helper, you must set up inbound firewall rules on the machine that is hosting the connector.
+1. Download Rabbit MQ Helper at one of the links below:
+
+   - [Directly from Thycotic CDN](https://thycocdn.azureedge.net/engineinstallerfiles-master/rabbitMqSiteConnector/grmqh.msi) 
+   - [From Thycotic CDN alias](https://updates.thycotic.net/links.ashx?RabbitMqInstaller) 
+   - [Pre-release](https://thycodevstorage.blob.core.windows.net/engineinstallerfiles-qa/rabbitMqSiteConnector/grmqh.msi) 
+
+2.	Choose the most appropriate installation scenario from the four below, but **do not run the associated script yet**:
+
+     - [Online Simple without TLS](installnontls.md)
+     - [Online Advanced with TLS](installnontls-offline.md)
+     - [Offline Simple without TLS](installtls.md)
+     - [Offline Advanced with TLS](installtls-offline.md)
+
+2. Launch the Helper (Thycotic.RabbitMq.Helper.exe) from the installation folder %PROGRAMFILES%\Thycotic Software Ltd\RabbitMq Helper. 
+      Thycotic.RabbitMq.Helper.exe prepares and runs a Windows PowerShell instance that is pre-configured to use the RabbitMQ Helper PowerShell module.
+
+4. Run PowerShell cmdlets that apply to your installation needs, or use the most appropriate script from the four choices listed above. 
+ > Note: RabbitMQ Helper provides the built-in cmdlet, Install-Connector, which is a prerequisite for installing any of the sample installation scripts. **You MUST install RabbitMQ Helper before running any of the scripts**. If you choose to use one of the Offline installation scripts, you must first install the script on [this page](installation/prepare-offline.md).
+
+After installation, the Helper opens a browser to the RabbitMQ management console, which you can close for now.
+
+## Validate the RabbitMQ Helper Installation
+
+1.	Return to Secret Server and navigate to the site connector you created previously.
+6.	Click the site connector link. 
+7.	On the Site Connector Details page, click the **Validate Connectivity** button.
+
+    If see **Validation Succeeded**, everything is set up correctly.
+
+    If you see **Validation Failed**, do the following: 
+    1. Ensure that the RabbitMQ Windows service is running. 
+    2. Check the logs found under **C:\Program Files\Thycotic Software Ltd\RabbitMq Site Connector\log**.
+    3. Check the SS system log for a full error report.
+
 
 ## How to Uninstall Rabbit
 
 > This command will remove both RabbitMq and Erlang from the current system. Before running this, if you’re having issues with Rabbit, it’s recommended to look at the troubleshooting section first.
 - [Uninstall RabbitMQ and Erlang](uninstall.md)
 
+## Overview of ```Install-Connector``` Workflow cmdlet 
 
-## Overview of ```Install-Connector``` Workflow cmdlet
 > The overview below is provided for informational purposes in order to explain the process in the Install-Connector cmdlet. Wherever possible, use the 'Install-Connector" commandlet to install Rabbit and not the individual commands below. See example installation sections above
 * License prompts and fine-print:
 * ```Get-ErlangInstaller``` - Download the installer for Erlang that it currently supported by Thycotic.


### PR DESCRIPTION
Added an installation procedure (previously missing) to the existing RabbitMQ Helper Installation page (https://docs.thycotic.com/rabbitmq-helper/2.0.0/installation).
Removed the now-redundant installation steps from https://docs.thycotic.com/rabbitmq-helper/2.0.0/index.md
I will consult with Will and Dobri about removing now-redundant installation steps from this Secret Server page: https://docs.thycotic.com/ss/10.9.0/secret-server-setup/installation/installing-rabbitmq/index.md

These steps will make the existing RabbitMQ Helper Installation page the single, definitive source for information on installing RabbitMQ Helper.