### PR TITLE
Updated to Erlang 24.0 & RabbitMq 3.9.5.

### DIFF
--- a/src/Thycotic.RabbitMq.Helper.Logic/InstallationConstants.cs
+++ b/src/Thycotic.RabbitMq.Helper.Logic/InstallationConstants.cs
@@ -22,7 +22,6 @@ namespace Thycotic.RabbitMq.Helper.Logic
         /// </summary>
         public static class Erlang
         {
-
             /// <summary>
             /// The erlang cookie file name
             /// </summary>
@@ -45,35 +44,27 @@ namespace Thycotic.RabbitMq.Helper.Logic
             ///     The erlang installer checksum
             /// </summary>
             public static readonly string InstallerChecksum =
-                Environment.Is64BitOperatingSystem 
-                ? "3f7a81bff20e419a1bf7e93a814527f64b7f4bbe35b1c68858aa7490a3a759a42bc399107ac369945b11ea757343354efe06b949758c373d481a435eaddcf0d9" 
-                : "7b0a33e88c6a52044b6468b162ebdbc9cb55327730ab6f441688e2c68d911bcafd5cd379f9add7b4574640cd198bffbde437bea54b39206dbda4d33d305efc44";
+                "d32322080dc3d36a9a3b2ccaea60932dd8a857058f5dc93ffcd887cb0bffec977eeaa628213830f4e74eb09274cea9e3cb32110b291fd645d28be81d34232d45";
 
             /// <summary>
             ///     The version
             /// </summary>
-            public static readonly Version Version = new Version(22, 2);
+            public static readonly Version Version = new Version(24, 0);
 
             /// <summary>
             ///     The download URL
             /// </summary>
-            public static readonly string DownloadUrl =
-                Environment.Is64BitOperatingSystem
-                    ? "http://erlang.org/download/otp_win64_22.2.exe"
-                    : "http://erlang.org/download/otp_win32_22.2.exe";
+            public static readonly string DownloadUrl = "https://erlang.org/download/otp_win64_24.0.exe";
 
             /// <summary>
             ///     The download URL using the Thycotic mirror
             /// </summary>
-            public static readonly string ThycoticMirrorDownloadUrl =
-                Environment.Is64BitOperatingSystem
-                    ? "https://thycocdn.azureedge.net/rabbitmqhelperfiles-master/erlang/otp_win64_22.2.exe"
-                    : "https://thycocdn.azureedge.net/rabbitmqhelperfiles-master/erlang/otp_win32_22.2.exe";
+            public static readonly string ThycoticMirrorDownloadUrl = "https://thycocdn.azureedge.net/rabbitmqhelperfiles-master/erlang/otp_win64_24.0.exe";
 
             /// <summary>
             ///     The install path
             /// </summary>
-            public static readonly string InstallPath = Path.Combine(EnvironmentalVariables.ProgramFiles, "erl10.6");
+            public static readonly string InstallPath = Path.Combine(EnvironmentalVariables.ProgramFiles, "erl-24.0");
 
             /// <summary>
             ///     The uninstaller path
@@ -86,6 +77,8 @@ namespace Thycotic.RabbitMq.Helper.Logic
                 Path.Combine(Environment.Is64BitOperatingSystem ? EnvironmentalVariables.ProgramFiles : EnvironmentalVariables.ProgramFiles32Bit, "erl9.3", "uninstall.exe"),
                 Path.Combine(Environment.Is64BitOperatingSystem ? EnvironmentalVariables.ProgramFiles : EnvironmentalVariables.ProgramFiles32Bit, "erl10.4", "uninstall.exe"),
                 Path.Combine(Environment.Is64BitOperatingSystem ? EnvironmentalVariables.ProgramFiles : EnvironmentalVariables.ProgramFiles32Bit, "erl10.6", "uninstall.exe"),
+                Path.Combine(Environment.Is64BitOperatingSystem ? EnvironmentalVariables.ProgramFiles : EnvironmentalVariables.ProgramFiles32Bit, "erl23.0", "uninstall.exe"),
+                Path.Combine(Environment.Is64BitOperatingSystem ? EnvironmentalVariables.ProgramFiles : EnvironmentalVariables.ProgramFiles32Bit, "erl24.0", "uninstall.exe"),
             };
         }
 
@@ -99,24 +92,24 @@ namespace Thycotic.RabbitMq.Helper.Logic
             /// The installer RabbitMq checksum
             /// </summary>
             public static readonly string InstallerChecksum =
-                "42be1f39c3511b85a422ce585d2756d751b35530a468c68c1f5e2167fe408a939b5689b3d665b36df49bdf120877090af0bbba7decda2dd74125e45e7600b54d";
+                "9bc2c72f6f9237981ca8994377c75ac5fbac5a99efefa44910355bef02bab51b18580a49b797a71a468759e0e43de4c65363e05dcbd0175e10db3e5098827856";
 
             /// <summary>
             ///     The download URL
             /// </summary>
             public const string DownloadUrl =
-                "https://github.com/rabbitmq/rabbitmq-server/releases/download/v3.8.2/rabbitmq-server-3.8.2.exe";
+                "https://github.com/rabbitmq/rabbitmq-server/releases/download/v3.9.5/rabbitmq-server-3.9.5.exe";
 
             /// <summary>
             ///     The download URL using the Thycotic mirror
             /// </summary>
             public const string ThycoticMirrorDownloadUrl =
-                "https://thycocdn.azureedge.net/rabbitmqhelperfiles-master/rabbitmq/rabbitmq-server-3.8.2.exe";
+                "https://thycocdn.azureedge.net/rabbitmqhelperfiles-master/rabbitmq/rabbitmq-server-3.9.5.exe";
 
             /// <summary>
             ///     The version
             /// </summary>
-            public static readonly Version Version = new Version(3, 8, 2);
+            public static readonly Version Version = new Version(3, 9, 5);
 
             /// <summary>
             ///     The configuration path
@@ -127,7 +120,7 @@ namespace Thycotic.RabbitMq.Helper.Logic
             ///     The install path
             /// </summary>
             public static readonly string InstallPath = Path.Combine(EnvironmentalVariables.ProgramFiles,
-                "RabbitMQ Server", "rabbitmq_server-3.8.2");
+                "RabbitMQ Server", "rabbitmq_server-3.9.5");
 
             /// <summary>
             ///     The bin dir

--- a/src/Thycotic.RabbitMq.Helper.PSCommands/Installation/UninstallErlangCommand.cs
+++ b/src/Thycotic.RabbitMq.Helper.PSCommands/Installation/UninstallErlangCommand.cs
@@ -55,8 +55,8 @@ namespace Thycotic.RabbitMq.Helper.PSCommands.Installation
                 
                 try
                 {
-                    const string erlandProcessKill = " /F /IM erl.exe";
-                    externalProcessRunner.Run("taskkill", workingPath, erlandProcessKill);
+                    const string erlangProcessKill = " /F /IM erl.exe";
+                    externalProcessRunner.Run("taskkill", workingPath, erlangProcessKill);
                 }
                 catch (Exception ex)
                 {
@@ -65,8 +65,8 @@ namespace Thycotic.RabbitMq.Helper.PSCommands.Installation
 
                 try
                 {
-                    const string erlandProcessKill = " /F /IM erlsrv.exe";
-                    externalProcessRunner.Run("taskkill", workingPath, erlandProcessKill);
+                    const string erlangProcessKill = " /F /IM erlsrv.exe";
+                    externalProcessRunner.Run("taskkill", workingPath, erlangProcessKill);
                 }
                 catch (Exception ex)
                 {
@@ -75,8 +75,8 @@ namespace Thycotic.RabbitMq.Helper.PSCommands.Installation
 
                 try
                 {
-                    const string erlandProcessKill = " /F /IM epmd.exe";
-                    externalProcessRunner.Run("taskkill", workingPath, erlandProcessKill);
+                    const string erlangProcessKill = " /F /IM epmd.exe";
+                    externalProcessRunner.Run("taskkill", workingPath, erlangProcessKill);
                 }
                 catch (Exception ex)
                 {

--- a/src/Thycotic.RabbitMq.Helper.PSCommands/Installation/Workflow/InstallConnectorCommand.cs
+++ b/src/Thycotic.RabbitMq.Helper.PSCommands/Installation/Workflow/InstallConnectorCommand.cs
@@ -289,7 +289,7 @@ namespace Thycotic.RabbitMq.Helper.PSCommands.Installation.Workflow
                         UseThycoticMirror = UseThycoticMirror
                     })
 
-                    .ReportProgress("Un-installing prior versions", 20)
+                    .ReportProgress("Uninstalling prior versions", 20)
                     .Then(() => new UninstallRabbitMqCommand())
                     .Then(() => new UninstallErlangCommand())
 

--- a/src/Thycotic.RabbitMq.Helper.PSCommands/Installation/Workflow/UninstallConnectorCommand.cs
+++ b/src/Thycotic.RabbitMq.Helper.PSCommands/Installation/Workflow/UninstallConnectorCommand.cs
@@ -25,17 +25,17 @@ namespace Thycotic.RabbitMq.Helper.PSCommands.Installation.Workflow
         /// </summary>
         protected override void ProcessRecord()
         {
-            using (var workflow = new CmdletWorkflow(this, "Un-installing"))
+            using (var workflow = new CmdletWorkflow(this, "Uninstalling"))
             {
                 workflow
-                    .ReportProgress("Un-installing RabbitMq", 10)
+                    .ReportProgress("Uninstalling RabbitMq", 10)
                     .Then(() => new UninstallRabbitMqCommand())
 
-                    .ReportProgress("Un-installing Erlang", 30)
+                    .ReportProgress("Uninstalling Erlang", 30)
                     .Then(() => new UninstallErlangCommand())
                     
 
-                    .Then(() => WriteVerbose("Connector has been un-installed."))
+                    .Then(() => WriteVerbose("Connector has been uninstalled."))
                     .Invoke();
             }
         }

--- a/src/Thycotic.RabbitMq.Helper/Program.cs
+++ b/src/Thycotic.RabbitMq.Helper/Program.cs
@@ -70,7 +70,7 @@ namespace Thycotic.RabbitMq.Helper
 
                     if (process.ExitCode != 0 && process.ExitCode != -1073741510)
                     {
-                        throw new ApplicationFailedException($"PowerShell existed with unexpected code {process.ExitCode}");
+                        throw new ApplicationFailedException($"PowerShell exited with unexpected code {process.ExitCode}");
                     }
 
                 });
@@ -90,7 +90,7 @@ namespace Thycotic.RabbitMq.Helper
             catch (Exception ex)
             {
                 Console.ForegroundColor = ConsoleColor.Red;
-                Console.WriteLine("Error occured:");
+                Console.WriteLine("Error occurred:");
 
                 var ex2 = ex;
 


### PR DESCRIPTION
Updated for Erlang 24.0 & RabbitMq 3.9.5.
Removed 32-bit Erlang support (RMQ no longer supports 32-bit Erlang).
Fixed typos.