### PR TITLE
Reference cluster doc from install doc, fix grammar, fix quotes

### DIFF
--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -5,60 +5,67 @@
 # Installing RabbitMQ with RabbitMQ Helper
 
 ## RabbitMQ and RabbitMQ Helper
-RabbitMQ is an important component of Secret Server’s on-premises environment, providing a robust framework for queuing messages between Secret Server and its Distributed Engines. RabbitMQ is an enterprise-ready software package that provides reliability and clustering functionality superior to other applications. RabbitMQ is not a Thycotic product and we receive no revenue from it. For download links and detailed information about RabbitMQ go to https://www.rabbitmq.com/. 
+RabbitMQ is an important component of Secret Server’s on-premises environment, providing a robust framework for queuing messages between Secret Server and its Distributed Engines. RabbitMQ is an enterprise-ready software package that provides reliability and clustering functionality superior to other applications. RabbitMQ is not a Thycotic product and we receive no revenue from it. For download links and detailed information about RabbitMQ go to https://www.rabbitmq.com/.
 
-We built the Thycotic RabbitMQ Helper application to streamline our customers’ RabbitMQ installations. Thycotic only supports RabbitMQ/Erlang installations performed using RabbitMQ Helper on the Windows OS. 
+We built the Thycotic RabbitMQ Helper application to streamline our customers’ RabbitMQ installations. Thycotic only supports RabbitMQ/Erlang installations performed using RabbitMQ Helper on the Windows OS.
 
 The Helper provides multiple commandlets that perform the installation/un-installation steps, along with two workflow commandlets named ```Install-Connector``` and ```Uninstall-Connector```.
 
 ## Install RabbitMQ and set up a Site Connector
-1. Download RabbitMQ from the RabbitMQ [website](https://www.rabbitmq.com/). 
-1. Check the RabbitMQ installation [prerequisites and set up a Site Connector](https://docs.thycotic.com/ss/10.9.0/secret-server-setup/installation/installing-rabbitmq/index.md) in Secret Server
+1. Download RabbitMQ from the RabbitMQ [website](https://www.rabbitmq.com/).
+1. Check the RabbitMQ installation [prerequisites and set up a Site Connector](https://docs.thycotic.com/ss/11.1.0/secret-server-setup/installation/installing-rabbitmq/index.md) in Secret Server.
 
 
 ## Install RabbitMQ Helper
 > **Note**: Before installing RabbitMQ Helper, you must set up inbound firewall rules on the machine that is hosting the connector.
+
 1. Download Rabbit MQ Helper at one of the links below:
 
-   - [Directly from Thycotic CDN](https://thycocdn.azureedge.net/engineinstallerfiles-master/rabbitMqSiteConnector/grmqh.msi) 
-   - [From Thycotic CDN alias](https://updates.thycotic.net/links.ashx?RabbitMqInstaller) 
-   - [Pre-release](https://thycodevstorage.blob.core.windows.net/engineinstallerfiles-qa-blue/rabbitMqSiteConnector/grmqh.msi
+   - [Directly from Thycotic CDN](https://thycocdn.azureedge.net/engineinstallerfiles-master/rabbitMqSiteConnector/grmqh.msi)
+   - [From Thycotic CDN alias](https://updates.thycotic.net/links.ashx?RabbitMqInstaller)
+   - [Pre-release](https://thycodevstorage.blob.core.windows.net/engineinstallerfiles-qa-blue/rabbitMqSiteConnector/grmqh.msi)
 
-2.	Choose the most appropriate installation scenario from the four below, but **do not run the associated script yet**:
+1.	Choose the most appropriate installation scenario from the four below, but **do not run the associated script yet**:
 
      - [Online Simple Installation without TLS](installnontls.md)
      - [Online Advanced Installation with TLS](installtls.md)
      - [Offline Simple Installation without TLS](installnontls-offline.md)
      - [Offline Advanced Installation with TLS](installtls-offline.md)
 
-2. Launch the Helper (Thycotic.RabbitMq.Helper.exe) from the installation folder %PROGRAMFILES%\Thycotic Software Ltd\RabbitMq Helper. 
+1. Launch the Helper (Thycotic.RabbitMq.Helper.exe) from the installation folder %PROGRAMFILES%\Thycotic Software Ltd\RabbitMq Helper.
       Thycotic.RabbitMq.Helper.exe prepares and runs a Windows PowerShell instance that is pre-configured to use the RabbitMQ Helper PowerShell module.
 
-4. Run PowerShell cmdlets that apply to your installation needs, or use the most appropriate script from the four choices listed above. 
+1. Run PowerShell cmdlets that apply to your installation needs, or use the most appropriate script from the four choices listed above.
  > Note: RabbitMQ Helper provides the built-in cmdlet, Install-Connector, which is a prerequisite for installing any of the sample installation scripts. **You MUST install RabbitMQ Helper before running any of the scripts**. If you choose to use one of the Offline installation scripts, you must first install the script on [this page](installation/prepare-offline.md).
 
-After installation, the Helper opens a browser to the RabbitMQ management console, which you can close for now.
+1. After installation, the Helper opens a browser to the [RabbitMQ management console](http://localhost:15672). From here, log in and go to the admin tab.
+
+1. Click the username SecretServer made.
+1. Under the Set Permissions section, click the "Set Permissions" button.
+1. Under the Update this User section, put in the password SecretServer made.
+  1. Under the Tags box, click "Admin".
+  1. Click the "Update User" button.
+1. To set up a cluster, see [RabbitMqCluster](../clustering/index.md).
 
 ## Validate the RabbitMQ Helper Installation
 
 1.	Return to Secret Server and navigate to the site connector you created previously.
-6.	Click the site connector link. 
-7.	On the Site Connector Details page, click the **Validate Connectivity** button.
+1.	Click the site connector link.
+1.	On the Site Connector Details page, click the **Validate Connectivity** button.
 
     If see **Validation Succeeded**, everything is set up correctly.
 
-    If you see **Validation Failed**, do the following: 
-    1. Ensure that the RabbitMQ Windows service is running. 
-    2. Check the logs found under **C:\Program Files\Thycotic Software Ltd\RabbitMq Site Connector\log**.
-    3. Check the SS system log for a full error report.
-
+    If you see **Validation Failed**, do the following:
+    1. Ensure that the RabbitMQ Windows service is running.
+    1. Check the logs found under **C:\Program Files\Thycotic Software Ltd\RabbitMq Site Connector\log**.
+    1. Check the SS system log for a full error report.
 
 ## How to Uninstall Rabbit
 
 > This command will remove both RabbitMq and Erlang from the current system. Before running this, if you’re having issues with Rabbit, it’s recommended to look at the troubleshooting section first.
 - [Uninstall RabbitMQ and Erlang](uninstall.md)
 
-## Overview of ```Install-Connector``` Workflow cmdlet 
+## Overview of ```Install-Connector``` Workflow cmdlet
 
 > The overview below is provided for informational purposes in order to explain the process in the Install-Connector cmdlet. Wherever possible, use the 'Install-Connector" commandlet to install Rabbit and not the individual commands below. See example installation sections above
 * License prompts and fine-print:
@@ -74,27 +81,17 @@ After installation, the Helper opens a browser to the RabbitMQ management consol
     * ```Convert-CaCerToPem``` - Convert CA certificate to PEM file format
     * ```Convert-PfxToPem``` - Convert Host PFX to PEM file format
     * ```New-RabbitMqTlsConfigFiles``` - Create RabbitMQ TLS configuration file
-    * ```Install-RabbitMq``` - Install RabbitMQ
-    * ```Copy-ErlangCookieFile``` - Copy the Erlang system cookie to the current user profile
-    * ```Assert-RabbitMqIsRunning``` - Assert RabbitMQ is running
-    * ```Enable-RabbitMqManagement``` - Enable RabbitMQ management UI
-    * ```New-RabbitMqUser``` - Create a basic user 
-    * ```Grant-RabbitMqUserPermission``` - Grant permissions to the created user
-    * ```Assert-RabbitMqConnectivity``` - Assert the newly create user can connect to RabbitMQ with TLS
-    * ```Open-RabbitMqManagement``` - Open the RabbitMQ management UI
 * Without TLS:
     * ```New-RabbitMqNonTlsConfigFiles``` - Create RabbitMQ non-TLS configuration file
-    * ```Install-RabbitMq``` - Install RabbitMQ
-    * ```Copy-ErlangCookieFile``` - Copy the Erlang system cookie to the current user profile
-    * ```Assert-RabbitMqIsRunning``` - Assert RabbitMQ is running
-    * ```Enable-RabbitMqManagement``` - Enable RabbitMQ management UI
-    * ```New-RabbitMqUser``` - Create a basic user 
-    * ```Grant-RabbitMqUserPermission``` - Grant permissions to the created user
-    * ```Assert-RabbitMqConnectivity``` - Assert the newly create user can connect to RabbitMQ without TLS
-    * ```Open-RabbitMqManagement``` - Open the RabbitMQ management UI
+* ```Install-RabbitMq``` - Install RabbitMQ
+* ```Copy-ErlangCookieFile``` - Copy the Erlang system cookie to the current user profile
+* ```Assert-RabbitMqIsRunning``` - Assert RabbitMQ is running
+* ```Enable-RabbitMqManagement``` - Enable RabbitMQ management UI
+* ```New-RabbitMqUser``` - Create a basic user
+* ```Grant-RabbitMqUserPermission``` - Grant permissions to the created user
+* ```Assert-RabbitMqConnectivity``` - Assert the newly create user can connect to RabbitMQ without TLS
+* ```Open-RabbitMqManagement``` - Open the RabbitMQ management UI
 
 ## Uninstall RabbitMQ Using the ```Uninstall-Connector``` Workflow cmdlet
 * ```Uninstall-RabbitMq``` - Uninstall prior installation (if any) of RabbitMQ and clean up
 * ```Uninstall-Erlang``` - Uninstall prior installation (if any) of Erlang and clean up
-
-

--- a/docs/installation/installnontls-offline.md
+++ b/docs/installation/installnontls-offline.md
@@ -11,10 +11,10 @@ You have to have the [Erlang and RabbitMq installers pre-downloaded](prepare-off
 ```powershell
 $path = "$env:programfiles\Thycotic Software Ltd\RabbitMq Helper\Examples";
 
-$cred = Get-Credential -Message "Enter the initial RabbitMq user username and password";
-#if you don't want to be prompted you can hardcode your credential in the script
-#$password = ConvertTo-SecureString “PlainTextPassword” -AsPlainText -Force
-#$cred = New-Object System.Management.Automation.PSCredential (“CustomUserName”, $password)
+$cred = Get-Credential -Message "Enter the initial RabbitMq user username and password.";
+#If you don't want to be prompted, you can hardcode your credential in the script.
+#$password = ConvertTo-SecureString "PlainTextPassword" -AsPlainText -Force
+#$cred = New-Object System.Management.Automation.PSCredential ("CustomUserName", $password)
 
 Install-Connector `
     -Credential $cred `
@@ -23,4 +23,4 @@ Install-Connector `
     -Verbose;
 ```
 
-There are more switches for this commandlet, your run "get-help install-connector" when inside the helper for more information
+There are more switches for this commandlet. Run "get-help install-connector" when inside the helper for more information.

--- a/docs/installation/installnontls.md
+++ b/docs/installation/installnontls.md
@@ -5,14 +5,14 @@
 # Online Simple Installation without TLS
 
 ```powershell
-$cred = Get-Credential -Message "Enter the initial RabbitMq user username and password";
-#if you don't want to be prompted you can hardcode your credential in the script
-#$password = ConvertTo-SecureString “PlainTextPassword” -AsPlainText -Force
-#$cred = New-Object System.Management.Automation.PSCredential (“CustomUserName”, $password)
+$cred = Get-Credential -Message "Enter the initial RabbitMq user username and password.";
+#If you don't want to be prompted, you can hardcode your credential in the script.
+#$password = ConvertTo-SecureString "PlainTextPassword" -AsPlainText -Force
+#$cred = New-Object System.Management.Automation.PSCredential ("CustomUserName", $password)
 
 Install-Connector `
     -Credential $cred `
     -UseThycoticMirror -Verbose
 ```
 
-There are more switches for this commandlet, your run "get-help install-connector" when inside the helper for more information
+There are more switches for this commandlet. Run "get-help install-connector" when inside the helper for more information.


### PR DESCRIPTION
It looks like some people have been copy/pasting from Microsoft programs into the files. Unfortunately, this causes a lot of issues when you want to preserve content accurately. I fixed 2 common mutations in the files I was otherwise improving:
- extra space at the end of a line
-  curled quotes ( “ ” ) instead of normal quotes ( " " )
If you are going to use an MS product for holding, sending, receiving, copying, or pasting text, you will have to take extra care to clean up after it.

I fixed a few minor grammar that I noticed, but this is by no means a proofreading, even of the files I touched. There are definite improvements that can be made in the future such as preparing the scripts to distribute to the client directly through product distribution/update channels.